### PR TITLE
OK-555 hakemusmaksu support

### DIFF
--- a/oph-configuration/config.dev.edn
+++ b/oph-configuration/config.dev.edn
@@ -14,7 +14,8 @@
                                           :merchant-secret  "SAIPPUAKAUPPIAS"}
                         :callback-uri       "https://maksut-local.test:9000/maksut/api/payment/paytrail"
                         :order-id-prefix    {:tutu "TTU"
-                                             :astu "ASTU"}
+                                             :astu "ASTU"
+                                             :kkhakemusmaksu "KKHA"}
                         :currency           "EUR"}
  :tutu                 {:lasku-origin       "tutu"
                         :order-id-prefix    "TTU"}

--- a/oph-configuration/config.dev.edn
+++ b/oph-configuration/config.dev.edn
@@ -9,9 +9,12 @@
                         :database-name "maksut"
                         :host          "localhost"
                         :port          15499}
- :payment              {:paytrail-config {:host             "https://services.paytrail.com/payments"
-                                          :merchant-id       375917
-                                          :merchant-secret  "SAIPPUAKAUPPIAS"}
+ :payment              {:paytrail-config {:default {:host             "https://services.paytrail.com/payments"
+                                                    :merchant-id       375917
+                                                    :merchant-secret  "SAIPPUAKAUPPIAS"}
+                                          :kkhakemusmaksu {:host             "https://services.paytrail.com/payments"
+                                                           :merchant-id       375917
+                                                           :merchant-secret  "SAIPPUAKAUPPIAS"}}
                         :callback-uri       "https://maksut-local.test:9000/maksut/api/payment/paytrail"
                         :order-id-prefix    {:tutu "TTU"
                                              :astu "ASTU"

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -10,7 +10,8 @@
                                           :merchant-secret  "{{ maksut_payment_paytrail_secret | default('SAIPPUAKAUPPIAS')}}"}
                         :callback-uri       "{{ maksut_payment_callback_uri }}"
                         :order-id-prefix    {:tutu "TTU"
-                                             :astu "ASTU"}
+                                             :astu "ASTU"
+                                             :kkhakemusmaksu "KKHA"}
                         :currency           "EUR"}
  :tutu                 {:lasku-origin       "tutu"
                         :order-id-prefix    "TTU"}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -5,9 +5,12 @@
                         :database-name "{{ maksut_db_name | default('maksut') }}"
                         :host          "{{ maksut_db_host }}"
                         :port          {{ maksut_db_port | default('5432') }}}
- :payment              {:paytrail-config {:host             "{{ maksut_payment_paytrail_host | default('https://services.paytrail.com/payments')}}"
-                                          :merchant-id       {{ maksut_payment_paytrail_id | default('375917')}}
-                                          :merchant-secret  "{{ maksut_payment_paytrail_secret | default('SAIPPUAKAUPPIAS')}}"}
+ :payment              {:paytrail-config {:default {:host             "{{ maksut_payment_paytrail_host | default('https://services.paytrail.com/payments')}}"
+                                                    :merchant-id       {{ maksut_payment_paytrail_id | default('375917')}}
+                                                    :merchant-secret  "{{ maksut_payment_paytrail_secret | default('SAIPPUAKAUPPIAS')}}"}
+                                          :kkhakemusmaksu {:host             "{{ maksut_payment_kkhakemusmaksu_paytrail_host | default('https://services.paytrail.com/payments')}}"
+                                                           :merchant-id       {{ maksut_payment_kkhakemusmaksu_paytrail_id | default('375917')}}
+                                                           :merchant-secret  "{{ maksut_payment_kkhakemusmaksu_paytrail_secret | default('SAIPPUAKAUPPIAS')}}"}}
                         :callback-uri       "{{ maksut_payment_callback_uri }}"
                         :order-id-prefix    {:tutu "TTU"
                                              :astu "ASTU"

--- a/oph-configuration/config.test.github.edn
+++ b/oph-configuration/config.test.github.edn
@@ -10,7 +10,8 @@
                                           :merchant-secret  "sikrot"}
                         :callback-uri       "<ei käytetä mock paytrail käyttöliittymätestissä>"
                         :order-id-prefix    {:tutu "TTU"
-                                             :astu "ASTU"}
+                                             :astu "ASTU"
+                                             :kkhakemusmaksu "KKHA"}
                         :currency           "EUR"}
  :tutu                 {:lasku-origin       "tutu"
                         :order-id-prefix    "TTU"}

--- a/oph-configuration/config.test.github.edn
+++ b/oph-configuration/config.test.github.edn
@@ -5,9 +5,12 @@
                         :database-name "maksut"
                         :host          "localhost"
                         :port          5432}
- :payment              {:paytrail-config {:host             "http://localhost:9040/payments"
-                                          :merchant-id      12345
-                                          :merchant-secret  "sikrot"}
+ :payment              {:paytrail-config {:default {:host             "http://localhost:9040/payments"
+                                                    :merchant-id      12345
+                                                    :merchant-secret  "sikrot"}
+                                          :kkhakemusmaksu {:host             "http://localhost:9040/payments"
+                                                           :merchant-id      12345
+                                                           :merchant-secret  "sikrot"}}
                         :callback-uri       "<ei käytetä mock paytrail käyttöliittymätestissä>"
                         :order-id-prefix    {:tutu "TTU"
                                              :astu "ASTU"

--- a/oph-configuration/config.test.local-environment.edn
+++ b/oph-configuration/config.test.local-environment.edn
@@ -10,7 +10,8 @@
                                           :merchant-secret  "sikrot"}
                         :callback-uri       "http://localhost:19033/maksut/payment/paytrail"
                         :order-id-prefix    {:tutu "TTU"
-                                             :astu "ASTU"}
+                                             :astu "ASTU"
+                                             :kkhakemusmaksu "KKHA"}
                         :currency           "EUR"}
  :tutu                 {:lasku-origin       "tutu"
                         :order-id-prefix    "TTU"}

--- a/oph-configuration/config.test.local-environment.edn
+++ b/oph-configuration/config.test.local-environment.edn
@@ -5,9 +5,12 @@
                         :database-name "maksut"
                         :host          "localhost"
                         :port          15432}
- :payment              {:paytrail-config {:host             "http://localhost:9040/payments"
-                                          :merchant-id      12345
-                                          :merchant-secret  "sikrot"}
+ :payment              {:paytrail-config {:default {:host             "http://localhost:9040/payments"
+                                                    :merchant-id      12345
+                                                    :merchant-secret  "sikrot"}
+                                          :kkhakemusmaksu {:host             "http://localhost:9040/payments"
+                                                           :merchant-id      12345
+                                                           :merchant-secret  "sikrot"}}
                         :callback-uri       "http://localhost:19033/maksut/payment/paytrail"
                         :order-id-prefix    {:tutu "TTU"
                                              :astu "ASTU"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.1",
         "create-react-class": "^15.7.0",
+        "husky": "^9.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -24,7 +25,6 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-playwright": "^0.15.3",
         "eslint-plugin-prettier": "^5.0.0",
-        "husky": "^9.0.11",
         "lint-prepush": "^2.1.0",
         "lint-staged": "^10.5.0",
         "pm2": "^4.5.6",
@@ -6496,12 +6496,12 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
-      "dev": true,
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "license": "MIT",
       "bin": {
-        "husky": "bin.mjs"
+        "husky": "bin.js"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-playwright": "^0.15.3",
     "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^9.0.11",
     "lint-prepush": "^2.1.0",
     "lint-staged": "^10.5.0",
     "pm2": "^4.5.6",
@@ -53,6 +52,7 @@
   "dependencies": {
     "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.1",
     "create-react-class": "^15.7.0",
+    "husky": "^9.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/src/clj/maksut/config.clj
+++ b/src/clj/maksut/config.clj
@@ -17,7 +17,8 @@
                                             :merchant-secret  s/Str}
                           :callback-uri       s/Str
                           :order-id-prefix    {:tutu s/Str
-                                               :astu s/Str}
+                                               :astu s/Str
+                                               :kkhakemusmaksu s/Str}
                           :currency           s/Str}
    :tutu                 {:lasku-origin       s/Str
                           :order-id-prefix    s/Str}

--- a/src/clj/maksut/config.clj
+++ b/src/clj/maksut/config.clj
@@ -12,9 +12,12 @@
                           :database-name s/Str
                           :host          s/Str
                           :port          s/Int}
-   :payment              {:paytrail-config {:host             s/Str
-                                            :merchant-id      s/Int
-                                            :merchant-secret  s/Str}
+   :payment              {:paytrail-config {:default {:host             s/Str
+                                                      :merchant-id      s/Int
+                                                      :merchant-secret  s/Str}
+                                            :kkhakemusmaksu {:host             s/Str
+                                                             :merchant-id      s/Int
+                                                             :merchant-secret  s/Str}}
                           :callback-uri       s/Str
                           :order-id-prefix    {:tutu s/Str
                                                :astu s/Str

--- a/src/clj/maksut/payment/payment_service.clj
+++ b/src/clj/maksut/payment/payment_service.clj
@@ -220,6 +220,19 @@
                                        :unit-price (/ checkout-amount-in-euro-cents 100)
                                        :vat vat-zero}]
                                      storage-engine oppija-baseurl))
+    "kkhakemusmaksu" (do
+             ;TODO: hakemusmaksu email
+             (handle-tutu-email-confirmation email-service email locale order-id
+                                             reference)
+             (handle-payment-receipt email-service email locale
+                                     first-name last-name
+                                     order-id (* 1000 timestamp)
+                                     (/ checkout-amount-in-euro-cents 100)
+                                     [{:description (create-receipt-description locale order-id)
+                                       :units 1
+                                       :unit-price (/ checkout-amount-in-euro-cents 100)
+                                       :vat vat-zero}]
+                                     storage-engine oppija-baseurl))
     nil))
 
 (defn- process-success-callback [this db email-service pt-params locale storage-engine _]

--- a/src/cljc/maksut/api_schemas.cljc
+++ b/src/cljc/maksut/api_schemas.cljc
@@ -11,7 +11,8 @@
 (s/defschema Origin
   (s/enum
     "tutu"
-    "astu"))
+    "astu"
+    "kkhakemusmaksu"))
 
 (s/defschema LocalizationEntity
   {:id       s/Int

--- a/src/cljc/maksut/api_schemas.cljc
+++ b/src/cljc/maksut/api_schemas.cljc
@@ -60,16 +60,21 @@
    :index (s/constrained s/Int #(<= 1 % 2) 'valid-tutu-maksu-index)})
 
 (s/defschema LaskuCreate
-  {(s/optional-key :order-id) s/Str
-   :first-name s/Str
-   :last-name s/Str
-   :email s/Str
-   :amount s/Str
-   (s/optional-key :due-date) (s/maybe s/Str) ;If not defined, then due-days used
-   :due-days (s/constrained s/Int #(> % 0) 'positive-due-days)
-   :origin Origin
-   :reference s/Str
-   (s/optional-key :index) (s/constrained s/Int #(<= 1 % 2) 'valid-tutu-maksu-index)})
+  (s/constrained
+    {(s/optional-key :order-id) s/Str
+     :first-name s/Str
+     :last-name s/Str
+     :email s/Str
+     :amount s/Str
+     (s/optional-key :due-date) (s/maybe s/Str)
+     (s/optional-key :due-days) (s/constrained s/Int #(> % 0) 'positive-due-days)
+     :origin Origin
+     :reference s/Str
+     (s/optional-key :index) (s/constrained s/Int #(<= 1 % 2) 'valid-tutu-maksu-index)}
+  (fn [{:keys [due-date due-days]}]
+    (or due-date due-days))
+    'must-have-either-due-date-or-due-days))
+
 
 (s/defschema LaskuStatus
   {:order-id s/Str

--- a/src/cljc/maksut/api_schemas.cljc
+++ b/src/cljc/maksut/api_schemas.cljc
@@ -75,7 +75,6 @@
     (or due-date due-days))
     'must-have-either-due-date-or-due-days))
 
-
 (s/defschema LaskuStatus
   {:order-id s/Str
    :reference s/Str

--- a/src/maksut-ui/app/components/KkHakemusmaksuPanel.tsx
+++ b/src/maksut-ui/app/components/KkHakemusmaksuPanel.tsx
@@ -1,0 +1,17 @@
+import { Lasku } from "@/app/lib/types";
+import styles from "@/app/page.module.css";
+import Maksu from "@/app/components/Maksu";
+import { Box } from "@mui/material";
+
+const KkHakemusmaksuPanel = ({lasku}: {lasku: Lasku}) => {
+  return (
+    <>
+      <h2>{lasku.reference}</h2>
+      <span>Hakemusmaksu ipsum</span>
+      <Box className={styles.maksut}>
+        <Maksu lasku={lasku}/>
+      </Box>
+    </>)
+}
+
+export default KkHakemusmaksuPanel

--- a/src/maksut-ui/app/components/MaksutPanel.tsx
+++ b/src/maksut-ui/app/components/MaksutPanel.tsx
@@ -3,6 +3,7 @@
 import { Lasku } from "@/app/lib/types";
 import TutuPanel from "@/app/components/TutuPanel";
 import AstuPanel from "@/app/components/AstuPanel";
+import KkHakemusmaksuPanel from "@/app/components/KkHakemusmaksuPanel";
 import { Box, useTheme } from "@mui/material";
 import { Button, colors } from "@opetushallitus/oph-design-system"
 import { backendUrl } from "@/app/lib/configurations";
@@ -22,6 +23,8 @@ export default function MaksutPanel({ laskut, secret, locale }: {laskut: Array<L
         return <TutuPanel laskut={laskut}/>
       case 'astu':
         return <AstuPanel lasku={activeLasku}/>
+      case 'kkhakemusmaksu':
+        return <KkHakemusmaksuPanel lasku={activeLasku}/>
     }
   }
 

--- a/src/maksut-ui/app/lib/types.ts
+++ b/src/maksut-ui/app/lib/types.ts
@@ -1,6 +1,6 @@
 export type PaymentStatus = 'active' | 'paid' | 'overdue'
 
-export type Origin = 'tutu' | 'astu' | 'kk'
+export type Origin = 'tutu' | 'astu' | 'kkhakemusmaksu'
 
 export type Locale = 'fi' | 'en' | 'sv'
 


### PR DESCRIPTION
Add barebones hakemusmaksu support for maksut, including the possibility to configure a separate merchant id for the payments

- TODO: order id logic
- TODO (perhaps as a separate task): styling, text content