### PR TITLE
OPHHAMA-4: Hakemusmaksun maksutilojen manuaalimuokkaukset Swaggerissa

### DIFF
--- a/src/clj/maksut/maksut/db/maksut_queries.clj
+++ b/src/clj/maksut/maksut/db/maksut_queries.clj
@@ -23,9 +23,24 @@
 (declare insert-payment!)
 (declare insert-secret-for-invoice!)
 (declare invalidate-laskut-by-reference!)
+(declare force-invalidate-laskut-by-reference!)
+(declare delete-secrets-by-reference!)
+(declare delete-laskut-by-reference!)
+(declare update-laskut-due-date-by-reference!)
 
 (defn invalidate-laskut-by-reference [db refs]
   (invalidate-laskut-by-reference! db {:refs refs}))
+
+(defn force-invalidate-laskut-by-reference [db refs]
+  (force-invalidate-laskut-by-reference! db {:refs refs}))
+
+(defn delete-laskut-by-reference [db refs]
+  (with-db-transaction [tx db]
+    (delete-secrets-by-reference! tx {:refs refs})
+    (delete-laskut-by-reference! tx {:refs refs})))
+
+(defn update-laskut-due-date-by-reference [db refs due-date]
+  (update-laskut-due-date-by-reference! db {:refs refs :due-date due-date}))
 
 (defn- insert-new-secret [db invoice-id order-id]
   ;prefix secrets with order-id to force them unique even if random would generate two identical

--- a/src/clj/maksut/maksut/db/maksut_queries.sql
+++ b/src/clj/maksut/maksut/db/maksut_queries.sql
@@ -104,3 +104,25 @@ SELECT * FROM all_invoices WHERE reference = :reference;
 
 -- :name get-linked-lasku-statuses-by-reference :? :*
 SELECT order_id, reference, status, origin FROM all_invoices WHERE reference IN (:v*:refs) ORDER BY order_id;
+
+-- :name force-invalidate-laskut-by-reference! :! :n
+UPDATE invoices
+SET invalidated_at = now()
+WHERE reference IN (:v*:refs)
+  AND id NOT IN (SELECT fk_invoice FROM payments);
+
+-- :name delete-secrets-by-reference! :! :n
+DELETE FROM secrets
+WHERE fk_invoice IN (SELECT id FROM invoices WHERE reference IN (:v*:refs)
+                       AND id NOT IN (SELECT fk_invoice FROM payments));
+
+-- :name delete-laskut-by-reference! :! :n
+DELETE FROM invoices
+WHERE reference IN (:v*:refs)
+  AND id NOT IN (SELECT fk_invoice FROM payments);
+
+-- :name update-laskut-due-date-by-reference! :! :n
+UPDATE invoices
+SET due_date = :due-date::date
+WHERE reference IN (:v*:refs)
+  AND id NOT IN (SELECT fk_invoice FROM payments);

--- a/src/clj/maksut/maksut/maksut_service.clj
+++ b/src/clj/maksut/maksut/maksut_service.clj
@@ -173,8 +173,29 @@
 
   ; Marks the payments invalid on our side so that it can't be accidentally paid anymore.
   (invalidate-laskut [_ _ input]
-    (log/info (str "Invalidating invoices with references:" keys))
     (let [{:keys [keys]} input
+          _ (log/info (str "Invalidating invoices with references: " keys))
           _ (maksut-queries/invalidate-laskut-by-reference db keys)
           statuses (maksut-queries/check-laskut-statuses-by-reference db keys)]
-      (map LaskuStatus->json statuses))))
+      (map LaskuStatus->json statuses)))
+
+  ; Force-invalidates invoices regardless of due date (for overdue correction: ok-by-proxy).
+  (force-invalidate-laskut [_ _ input]
+    (let [{:keys [keys]} input]
+      (log/info "Force-invalidating invoices for" (count keys) "references")
+      (maksut-queries/force-invalidate-laskut-by-reference db keys)
+      (map LaskuStatus->json (maksut-queries/check-laskut-statuses-by-reference db keys))))
+
+  ; Deletes invoices and their secrets (for overdue correction: not-required).
+  (delete-laskut [_ _ input]
+    (let [{:keys [keys]} input
+          deleted (maksut-queries/delete-laskut-by-reference db keys)]
+      (log/info "Deleted" deleted "invoices and their secrets for" (count keys) "references")
+      {:deleted deleted}))
+
+  ; Updates due date on invoices (for overdue correction: awaiting with new due date).
+  (update-laskut-due-date [_ _ input]
+    (let [{:keys [keys due-date]} input]
+      (log/info "Updating due date to" due-date "for" (count keys) "references")
+      (maksut-queries/update-laskut-due-date-by-reference db keys due-date)
+      (map LaskuStatus->json (maksut-queries/check-laskut-statuses-by-reference db keys)))))

--- a/src/clj/maksut/maksut/maksut_service_protocol.clj
+++ b/src/clj/maksut/maksut/maksut_service_protocol.clj
@@ -8,4 +8,7 @@
   (get-lasku [this session order-id])
   (get-lasku-contact [this session secret])
   (get-laskut-by-secret [this session secret])
-  (invalidate-laskut [this session input]))
+  (invalidate-laskut [this session input])
+  (force-invalidate-laskut [this session input])
+  (delete-laskut [this session input])
+  (update-laskut-due-date [this session input]))

--- a/src/clj/maksut/routes.clj
+++ b/src/clj/maksut/routes.clj
@@ -156,6 +156,39 @@
                                (let [resp (maksut-protocol/invalidate-laskut maksut-service session input)]
                                  (response/ok resp)))}}]]
 
+       ["/lasku-force-invalidate"
+        [""
+         {:post {:middleware auth
+                 :tags       ["Lasku"]
+                 :summary    "Mitätöi laskut viitenumeron perusteella (myös erääntyneet)"
+                 :responses  {200 {:body schema/LaskuStatusList}}
+                 :parameters {:body schema/LaskuRefList}
+                 :handler    (fn [{session :session {input :body} :parameters}]
+                               (log/info "Force-invalidate invoices for" (count (:keys input)) "keys")
+                               (response/ok (maksut-protocol/force-invalidate-laskut maksut-service session input)))}}]]
+
+       ["/lasku-delete"
+        [""
+         {:post {:middleware auth
+                 :tags       ["Lasku"]
+                 :summary    "Poistaa laskut ja niiden salaisuudet viitenumeron perusteella"
+                 :responses  {200 {:body {:deleted s/Int}}}
+                 :parameters {:body schema/LaskuRefList}
+                 :handler    (fn [{session :session {input :body} :parameters}]
+                               (log/info "Delete invoices for" (count (:keys input)) "keys")
+                               (response/ok (maksut-protocol/delete-laskut maksut-service session input)))}}]]
+
+       ["/lasku-update-due-date"
+        [""
+         {:post {:middleware auth
+                 :tags       ["Lasku"]
+                 :summary    "Päivittää laskujen eräpäivän viitenumeroiden perusteella"
+                 :responses  {200 {:body schema/LaskuStatusList}}
+                 :parameters {:body schema/LaskuDueDateUpdate}
+                 :handler    (fn [{session :session {input :body} :parameters}]
+                               (log/info "Update due date for" (count (:keys input)) "keys to" (:due-date input))
+                               (response/ok (maksut-protocol/update-laskut-due-date maksut-service session input)))}}]]
+
        ["/lasku/:application-key"
         [""
          {:get {:middleware auth

--- a/src/clj/maksut/schemas/api_schemas.clj
+++ b/src/clj/maksut/schemas/api_schemas.clj
@@ -133,3 +133,7 @@
 
 (s/defschema LaskuStatusList
   [LaskuStatus])
+
+(s/defschema LaskuDueDateUpdate
+  {:keys  [s/Str]
+   :due-date s/Str})

--- a/test/clj/maksut/maksut/maksut_service_spec.clj
+++ b/test/clj/maksut/maksut/maksut_service_spec.clj
@@ -3,7 +3,8 @@
             [maksut.maksut.maksut-service-protocol :as maksut-protocol]
             [maksut.maksut.fixtures :as maksut-test-fixtures]
             [maksut.util.date :refer [plus-days-from-now]]
-            [maksut.test-fixtures :as test-fixtures :refer [test-system]]))
+            [maksut.test-fixtures :as test-fixtures :refer [test-system]])
+  (:import (java.sql Date)))
 
 (use-fixtures :once test-fixtures/with-mock-system)
 (use-fixtures :each test-fixtures/with-empty-database)
@@ -234,3 +235,67 @@
              (let [secret @first-secret]
                (let [list (maksut-protocol/get-laskut-by-secret service maksut-test-fixtures/fake-session secret)]
                  (is (->> list (map :order_id) sort) '(order-id order-id-2)))))))
+
+(deftest maksut-eraaantynyt-korjaus-test
+  (let [service     (:maksut-service @test-system)
+        db          (:db @test-system)
+        hannes      {:first-name "Hannes" :last-name "Snellmann" :email "hannes@gmail.com"}
+        ak-active   "1.2.246.562.11.00000000000000200001"
+        ak-overdue  "1.2.246.562.11.00000000000000200002"
+        ak-delete   "1.2.246.562.11.00000000000000200003"
+        ak-due-date "1.2.246.562.11.00000000000000200004"
+        new-date    (str (plus-days-from-now 30))]
+
+    (testing "force-invalidate-laskut invalidoi aktiivisen laskun"
+      (maksut-protocol/create service maksut-test-fixtures/fake-session
+        (merge hannes {:reference ak-active
+                       :origin    "kkhakemusmaksu"
+                       :amount    "100.00"
+                       :due-days  7}))
+      (let [result (maksut-protocol/force-invalidate-laskut service maksut-test-fixtures/fake-session
+                     {:keys [ak-active]})]
+        (is (= 1 (count result)))
+        (is (= :invalidated (:status (first result))))))
+
+    (testing "force-invalidate-laskut invalidoi erääntyneen laskun (ohittaa päivämääräehdon)"
+      (test-fixtures/add-invoice! db
+        {:order_id   "KKHA200002"
+         :first_name "Hannes"
+         :last_name  "Snellmann"
+         :email      "hannes@gmail.com"
+         :amount     100.00M
+         :origin     "kkhakemusmaksu"
+         :reference  ak-overdue
+         :due_date   (Date/valueOf "2020-01-01")})
+      (let [result (maksut-protocol/force-invalidate-laskut service maksut-test-fixtures/fake-session
+                     {:keys [ak-overdue]})]
+        (is (= 1 (count result)))
+        (is (= :invalidated (:status (first result))))))
+
+    (testing "delete-laskut poistaa laskun ja sen salaisuuden"
+      (maksut-protocol/create service maksut-test-fixtures/fake-session
+        (merge hannes {:reference ak-delete
+                       :origin    "kkhakemusmaksu"
+                       :amount    "100.00"
+                       :due-days  7}))
+      (is (= 1 (count (maksut-protocol/list-laskut service maksut-test-fixtures/fake-session
+                        {:application-key ak-delete}))))
+      (let [result (maksut-protocol/delete-laskut service maksut-test-fixtures/fake-session
+                     {:keys [ak-delete]})]
+        (is (= {:deleted 1} result)))
+      (is (= 0 (count (maksut-protocol/list-laskut service maksut-test-fixtures/fake-session
+                        {:application-key ak-delete})))))
+
+    (testing "update-laskut-due-date päivittää eräpäivän ja lasku pysyy aktiivisena"
+      (maksut-protocol/create service maksut-test-fixtures/fake-session
+        (merge hannes {:reference ak-due-date
+                       :origin    "kkhakemusmaksu"
+                       :amount    "100.00"
+                       :due-days  7}))
+      (let [statuses (maksut-protocol/update-laskut-due-date service maksut-test-fixtures/fake-session
+                       {:keys [ak-due-date] :due-date new-date})]
+        (is (= 1 (count statuses)))
+        (is (= :active (:status (first statuses)))))
+      (let [lasku (first (maksut-protocol/list-laskut service maksut-test-fixtures/fake-session
+                           {:application-key ak-due-date}))]
+        (is (= new-date (:due_date lasku)))))))


### PR DESCRIPTION
## Muutos

Lisätään kolme uutta endpointia hakemusmaksujen massaluonteista manuaalikorjausta varten (ataru PR [#1838](https://github.com/Opetushallitus/ataru/pull/1838)). Endpointit on tarkoitettu käytettäväksi vain ataru-palvelun kautta OPH-pääkäyttäjälle suunnatun Swagger-rajapinnan kautta.

## Uudet endpointit

| Endpoint | Kuvaus |
|---|---|
| `POST /api/lasku-force-invalidate` | Mitätöi laskut viitenumeroiden perusteella myös silloin kun lasku on erääntynyt (`invalidated_at = now()`). Ei koske maksettuja laskuja. |
| `POST /api/lasku-delete` | Poistaa laskut ja niihin liittyvät salaisuudet viitenumeroiden perusteella. |
| `POST /api/lasku-update-due-date` | Päivittää laskujen eräpäivän viitenumeroiden perusteella. Ei koske maksettuja laskuja. |

Kaikki endpointit käyttävät olemassa olevaa virkailija-autentikointia.

## Tekniset muutokset

- **SQL** (`maksut_queries.sql`): Kolme uutta kyselyä. `force-invalidate` ja `update-due-date` sisältävät `AND id NOT IN (SELECT fk_invoice FROM payments)` -ehdon, joka estää maksettujen laskujen muokkaamisen.
- **Protokolla** (`maksut_service_protocol.clj`): Kolme uutta protokollametodia.
- **Palvelu** (`maksut_service.clj`): Protokollan toteutukset. `delete-laskut` palauttaa oikeasti poistettujen rivien määrän (HugSQL `:! :n`). Korjattu myös olemassa olevan `invalidate-laskut`-metodin lokitusvirhe (`:keys` ei ollut `let`-sidonnassa).
- **Reitit** (`routes.clj`): Kolme uutta reittiä Swagger-dokumentaatioineen.
- **Schema** (`api_schemas.clj`): Uusi `LaskuDueDateUpdate`-schema eräpäivän päivitykselle.

## Riippuvuus

Tätä PR:ää käyttää ataru PR [#1838](https://github.com/Opetushallitus/ataru/pull/1838).