### PR TITLE
Add renovate.json for github-actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "enabledManagers": ["github-actions"],
+  "platformAutomerge": false,
+  "recreateWhen": "always",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
+      "groupName": "github-actions",
+      "commitMessageTopic": "github-actions versions"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "github-actions versions",
+      "minimumReleaseAge": "7 days"
+    }
+  ]
+}


### PR DESCRIPTION
Adds shared Renovate config to pin and update github-actions versions via digests.