### PR TITLE
OPHHAMA-24: lokita jos maksu tehdään tai valmistuu eräpäivän jälkeen

### DIFF
--- a/src/clj/maksut/maksut/db/maksut_queries.clj
+++ b/src/clj/maksut/maksut/db/maksut_queries.clj
@@ -1,9 +1,12 @@
 (ns maksut.maksut.db.maksut-queries
   (:require [maksut.error :refer [maksut-error]]
             [maksut.util.random :as random]
+            [maksut.util.date :as date]
             [hugsql.core :as hugsql]
             [clojure.java.jdbc :refer [with-db-transaction]]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log])
+  (:import (java.time Instant)
+           (java.time.temporal ChronoUnit)))
 
 
 (hugsql/def-db-fns "maksut/maksut/db/maksut_queries.sql")
@@ -91,6 +94,15 @@
 (defn check-laskut-statuses-by-reference [db refs]
   (get-linked-lasku-statuses-by-reference db {:refs refs}))
 
+(defn- warn-if-paid-late [order-number due-date timestamp]
+  (when due-date
+    (let [paid-date (-> (Instant/ofEpochSecond timestamp)
+                        (.atZone date/helsinki-zone)
+                        (.toLocalDate))
+          days-late (.until due-date paid-date ChronoUnit/DAYS)]
+      (when (pos? days-late)
+        (log/warn "Lasku" order-number "maksettu" days-late "päivää eräpäivän jälkeen")))))
+
 (defn create-payment [db order-number payment-id amount timestamp]
   (with-db-transaction
    [tx db]
@@ -120,6 +132,7 @@
                              :payment-id payment-id
                              :amount     (bigdec amount)
                              :timestamp  timestamp}) ;epoch seconds
+           (warn-if-paid-late order-number (:due_date lasku) timestamp)
            (assoc response :action :created))))
      (do
        (log/error "Payment cannot be processed as invoice not found for order_number " order-number)

--- a/test/clj/maksut/payment/payment_service_spec.clj
+++ b/test/clj/maksut/payment/payment_service_spec.clj
@@ -9,7 +9,8 @@
             [maksut.test-fixtures :as test-fixtures :refer [test-system
                                                             get-emails
                                                             is-email-count
-                                                            reset-emails!]])
+                                                            reset-emails!]]
+            [taoensso.timbre :as timbre])
   (:import (java.time LocalDate ZonedDateTime))
   (:use clj-http.fake))
 
@@ -474,3 +475,39 @@
                         (is (= (:code data) :invoice-invalidstate-paid)))))
 
            ))
+
+(deftest paid-after-due-date-logs-warning
+  (let [service  (:payment-service @test-system)
+        db       (:db @test-system)
+        due-date (LocalDate/parse "2020-01-01")
+        db-data  (db-invoice due-date)
+        locale   "fi"
+        logged   (atom [])]
+
+    (test-fixtures/add-invoice! db db-data)
+
+    (testing "Payment success callback logs a warning when paid long after due-date"
+      (timbre/with-merged-config
+        {:appenders {:test-capture {:enabled? true
+                                    :fn       (fn [data] (swap! logged conj (:vargs data)))}}}
+        (let [response (payment-protocol/process-success-callback service params locale false)]
+          (is (= (:action response) :created))))
+      (is (some #(s/includes? (apply str %) "eräpäivän jälkeen") @logged)))))
+
+(deftest paid-on-time-does-not-log-warning
+  (let [service  (:payment-service @test-system)
+        db       (:db @test-system)
+        due-date (plus-days-from-now 14)
+        db-data  (db-invoice due-date)
+        locale   "fi"
+        logged   (atom [])]
+
+    (test-fixtures/add-invoice! db db-data)
+
+    (testing "Payment success callback does not log a warning when paid before due-date"
+      (timbre/with-merged-config
+        {:appenders {:test-capture {:enabled? true
+                                    :fn       (fn [data] (swap! logged conj (:vargs data)))}}}
+        (let [response (payment-protocol/process-success-callback service params locale false)]
+          (is (= (:action response) :created))))
+      (is (not (some #(s/includes? (apply str %) "eräpäivän jälkeen") @logged))))))


### PR DESCRIPTION
https://jira.eduuni.fi/browse/OPHHAMA-24

## Tausta

Tikettiin liittyvässä tapauksessa hakija oli todennäköisesti avannut Paytrailin maksusivun ennen laskun eräpäivää ja jättänyt sen auki, ja suoritti maksun vasta muutama päivä eräpäivän jälkeen. Access-lokien ja tuotantodatan perusteella `/lasku/:order-id/maksa`-rajapinta toimi näissä tapauksissa oikein (maksa-kutsu tehtiin ennen eräpäivää). Todellinen viive syntyy Paytrailin puolella jo avatun maksusession suorittamisen ja meidän `process-success-callback`:n käsittelyn välillä, jota ei ole tarkoituksella sidottu eräpäivään (ks. koodissa jo ollut kommentti Paytrailin 5-7 vrk käsittelyviiveestä).

Maksa-napissa (`MaksaButton.tsx`) oli jo valmiiksi eräpäivätarkistus sekä frontissa että backendissa: nappi renderöityy vain kun laskun `status === 'active'`, eli se piiloutuu heti kun lasku muuttuu erääntyneeksi, ja backend myös tarkistaa eräpäivän ennen Paytrail formin kenttien muodostamista. Lisäksi maksut-ui käyttää `swr`-kirjastoa (otettu käyttöön Next.js → React Router -migraatiossa), joka oletusasetuksillaan hakee laskun tuoreen tilan backendistä lähes aina kun käyttäjä fokusoi selainikkunan/-välilehden takaisin (`revalidateOnFocus`), eli auki jätetty sivu päivittyy "erääntynyt"-tilaan heti kun käyttäjä palaa siihen, ja Maksa-nappi katoaa. Tämä ei kuitenkaan auta tapauksessa, jossa käyttäjä on jo aiemmin siirtynyt Paytrailiin, mikä on todennäköisimmin juuri se reitti jota kautta havaitut tapaukset syntyivät. Havaitut maksuviiveet tuotannossa ovat olleet lyhyitä (1-3 vrk). Maksuviiveet on selvitetty kannasta katsomalla:
```
SELECT
      i.order_id,
      i.due_date,
      p.paid_at AS paid_at,
      (p.paid_at::date - i.due_date) AS days_late
  FROM invoices i
  JOIN payments p ON p.fk_invoice = i.id
  WHERE p.paid_at::date > i.due_date
  ORDER BY days_late DESC;
```

## Muutos

- `create-payment`: kun uusi maksu kirjataan, lasketaan päivien määrä laskun `due_date`:n ja maksun toteutumispäivän (`timestamp`, Helsingin aikavyöhykkeellä) välillä.
- Jos maksu on tullut eräpäivän jälkeen, kirjoitetaan `log/warn`-tason lokirivi (`Lasku <order-id> maksettu <N> päivää eräpäivän jälkeen`).